### PR TITLE
refactor: add refs to components without refs

### DIFF
--- a/packages/badge/src/feedback-badge.tsx
+++ b/packages/badge/src/feedback-badge.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, VoidFunctionComponent } from 'react'
+import React, { Ref, useMemo } from 'react'
 import styled from '@emotion/styled'
 import { Check, Close } from '@icon-park/react'
 import { iconProps, layout, LayoutProps, spacing, SpacingProps } from '@novem-ui/base'
@@ -25,14 +25,14 @@ const ColoredCircle = styled.div<FeedbackBadgeProps>`
   }
 `
 
-const FeedbackBadge: VoidFunctionComponent<FeedbackBadgeProps> = ({ variant, ...props }) => {
+const FeedbackBadge = ({ variant, ...props }: FeedbackBadgeProps, ref: Ref<HTMLDivElement>): JSX.Element => {
   const Icon = useMemo(() => (variant === 'success' ? Check : Close), [variant])
 
   return (
-    <ColoredCircle variant={variant} {...props}>
+    <ColoredCircle variant={variant} {...props} ref={ref}>
       <Icon {...iconProps} />
     </ColoredCircle>
   )
 }
 
-export default FeedbackBadge
+export default React.forwardRef<HTMLDivElement, FeedbackBadgeProps>(FeedbackBadge)

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -32,11 +32,13 @@
     "url": "https://github.com/jdrets/novem-ui/issues"
   },
   "devDependencies": {
+    "@types/merge-refs": "^1.0.0",
     "@types/novem-theme": "^0.0.1-alpha.1"
   },
   "dependencies": {
     "@novem-ui/base": "^0.0.1",
     "@novem-ui/theme": "^0.0.1-alpha.1",
+    "merge-refs": "^1.0.0",
     "polished": "^4.1.3"
   },
   "peerDependencies": {

--- a/packages/checkbox/src/index.tsx
+++ b/packages/checkbox/src/index.tsx
@@ -1,4 +1,5 @@
-import React, { HTMLProps, useEffect, useMemo, useRef, VoidFunctionComponent } from 'react'
+import React, { HTMLProps, Ref, useEffect, useMemo, useRef } from 'react'
+import mergeRefs from 'merge-refs'
 import { iconProps, separateSpacingProps, SolidColorWithHierarchyProps, SpacingProps } from '@novem-ui/base'
 import { Check, Minus } from '@icon-park/react'
 
@@ -12,11 +13,15 @@ export type CheckboxProps = Omit<HTMLProps<HTMLInputElement>, 'type' | 'as'> &
     indeterminate?: boolean
   }
 
-const Checkbox: VoidFunctionComponent<CheckboxProps> = ({ baseColor, indeterminate, checked, ...checkboxProps }) => {
+const Checkbox = (
+  { baseColor, indeterminate, checked, ...checkboxProps }: CheckboxProps,
+  ref: Ref<HTMLInputElement>
+): JSX.Element => {
   const { props, spacingProps } = useMemo(() => separateSpacingProps<typeof checkboxProps>(checkboxProps), [
     checkboxProps
   ])
   const checkboxRef = useRef<HTMLInputElement>(null)
+  const internalCheckboxRef = useMemo(() => mergeRefs(checkboxRef, ref), [checkboxRef, ref])
 
   useEffect(() => {
     checkboxRef.current.indeterminate = indeterminate
@@ -24,7 +29,7 @@ const Checkbox: VoidFunctionComponent<CheckboxProps> = ({ baseColor, indetermina
 
   return (
     <CheckboxLabel {...spacingProps}>
-      <HiddenInput {...props} ref={checkboxRef} type="checkbox" baseColor={baseColor} checked={checked} />
+      <HiddenInput {...props} ref={internalCheckboxRef} type="checkbox" baseColor={baseColor} checked={checked} />
       <CheckboxElement baseColor={baseColor} />
       <Check className="checkbox-icon-check" {...iconProps} />
       <Minus className="checkbox-icon-minus" {...iconProps} />
@@ -32,4 +37,4 @@ const Checkbox: VoidFunctionComponent<CheckboxProps> = ({ baseColor, indetermina
   )
 }
 
-export default Checkbox
+export default React.forwardRef<HTMLInputElement, CheckboxProps>(Checkbox)

--- a/packages/switch/src/index.tsx
+++ b/packages/switch/src/index.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLProps, useMemo, VoidFunctionComponent } from 'react'
+import React, { HTMLProps, Ref, useMemo } from 'react'
 import { separateSpacingProps, SolidColorWithHierarchyProps, SpacingProps } from '@novem-ui/base'
 
 import HiddenInput from './hidden-input'
@@ -9,15 +9,15 @@ export type SwitchProps = Omit<HTMLProps<HTMLInputElement>, 'type' | 'as'> &
   Omit<SolidColorWithHierarchyProps, 'hierarchy' | 'theme'> &
   SpacingProps
 
-const Switch: VoidFunctionComponent<SwitchProps> = (props) => {
+const Switch = (props: SwitchProps, ref: Ref<HTMLInputElement>) => {
   const { props: inputProps, spacingProps } = useMemo(() => separateSpacingProps<typeof props>(props), [props])
 
   return (
     <SwitchLabel {...spacingProps}>
-      <HiddenInput {...inputProps} type="checkbox" />
+      <HiddenInput {...inputProps} type="checkbox" ref={ref} />
       <SwitchElement />
     </SwitchLabel>
   )
 }
 
-export default Switch
+export default React.forwardRef<HTMLInputElement, SwitchProps>(Switch)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3802,6 +3802,13 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/merge-refs@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/merge-refs/-/merge-refs-1.0.0.tgz#8145d23d5e7dd1066f897c28ff5d1b04d499e179"
+  integrity sha512-JBypCVWDsRDhAyA8wMkdu8RbD3E54QeDmKjtwDk0XQAI3/OhdPuSDX7PimMqRT6MKnTMQuz6XRUszS/09Aw1vw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/micromatch@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-4.0.1.tgz#9381449dd659fc3823fd2a4190ceacc985083bc7"
@@ -10704,6 +10711,11 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+
+merge-refs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/merge-refs/-/merge-refs-1.0.0.tgz#388348bce22e623782c6df9d3c4fc55888276120"
+  integrity sha512-WZ4S5wqD9FCR9hxkLgvcHJCBxzXzy3VVE6p8W2OzxRzB+hLRlcadGE2bW9xp2KSzk10rvp4y+pwwKO6JQVguMg==
 
 merge-stream@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
refactor some components that didn't had a way to pas the ref to the "principal" element, this will allow to use libraries such as react-hook-form with 0 difficulties