### PR TITLE
feat: add shadow props to layout components

### DIFF
--- a/packages/layout/src/box/__snapshots__/index.spec.tsx.snap
+++ b/packages/layout/src/box/__snapshots__/index.spec.tsx.snap
@@ -5,6 +5,7 @@ exports[`<Box /> should match snapshot (default) 1`] = `
   border: 1px solid;
   border-color: #9f1313;
   display: block;
+  box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1),0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
 <div>

--- a/packages/layout/src/box/index.spec.tsx
+++ b/packages/layout/src/box/index.spec.tsx
@@ -8,7 +8,7 @@ import { Box } from '.'
 describe('<Box />', () => {
   test('should match snapshot (default)', () => {
     const Component = () => (
-      <Box display="block" border="1px solid" borderColor="red.800">
+      <Box display="block" border="1px solid" borderColor="red.800" shadow="sm">
         Dummy text
       </Box>
     )

--- a/packages/layout/src/box/index.stories.tsx
+++ b/packages/layout/src/box/index.stories.tsx
@@ -21,3 +21,16 @@ Default.args = {
   borderStyle: 'solid',
   borderColor: 'orange.700'
 }
+
+export const Shadow = Template.bind({})
+
+Shadow.args = {
+  backgroundColor: 'blue.100',
+  width: '100%',
+  height: '100px',
+  borderRadius: '10px',
+  borderWidth: '1px',
+  borderStyle: 'solid',
+  borderColor: 'blue.300',
+  shadow: 'md'
+}

--- a/packages/layout/src/box/index.ts
+++ b/packages/layout/src/box/index.ts
@@ -7,14 +7,17 @@ import {
   BorderProps,
   BackgroundProps,
   LayoutProps,
-  SpacingProps
+  SpacingProps,
+  shadows,
+  ShadowProps
 } from '@novem-ui/base'
 
-export type BoxProps = BorderProps & BackgroundProps & LayoutProps & SpacingProps
+export type BoxProps = BorderProps & BackgroundProps & LayoutProps & SpacingProps & ShadowProps
 
 export const Box = styled.div<BoxProps>`
   ${border}
   ${background}
   ${layout}
   ${spacing}
+  ${shadows}
 `


### PR DESCRIPTION
Allow layout elements to have a shadow prop

<img width="773" alt="image" src="https://user-images.githubusercontent.com/16139979/148800600-97b6af9b-6c3e-4f79-a11e-185f2c85b052.png">
