### PR TITLE
fix: verify missing deps and bad imports

### DIFF
--- a/packages/button/src/index.spec.tsx
+++ b/packages/button/src/index.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import withTheme from '@novem-ui/theme/src/utils/with-theme'
+import { withTheme } from '@novem-ui/theme'
 import { render } from '@testing-library/react'
 
 import Button from '.'

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -10,6 +10,10 @@ export { default as Switch, SwitchProps } from '@novem-ui/switch'
 
 export { default as Checkbox, CheckboxProps } from '@novem-ui/checkbox'
 
+export { Message, MessageProps } from '@novem-ui/message'
+
+export { Box, Flex, BoxProps, FlexProps } from '@novem-ui/layout'
+
 export { Heading, Label, Paragraph, HeadingProps, LabelProps, ParagraphProps } from '@novem-ui/text'
 
 export { Input, TextField, TextFieldProps, Option, OptionProps, Dropdown, DropdownProps } from '@novem-ui/input'

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -12,7 +12,7 @@ export { default as Checkbox, CheckboxProps } from '@novem-ui/checkbox'
 
 export { Heading, Label, Paragraph, HeadingProps, LabelProps, ParagraphProps } from '@novem-ui/text'
 
-export { Input, TextField, TextFieldProps } from '@novem-ui/input'
+export { Input, TextField, TextFieldProps, Option, OptionProps, Dropdown, DropdownProps } from '@novem-ui/input'
 
 export { default as theme } from '@novem-ui/theme'
 export type { Theme } from '@novem-ui/theme'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,8 +25,10 @@
   "dependencies": {
     "@novem-ui/badge": "^0.0.1-alpha.1",
     "@novem-ui/button": "^0.0.1-alpha.1",
+    "@novem-ui/checkbox": "^0.0.1-alpha.1",
     "@novem-ui/input": "^0.0.1",
     "@novem-ui/layout": "^0.0.1",
+    "@novem-ui/message": "^0.0.1",
     "@novem-ui/switch": "^0.0.1-alpha.1",
     "@novem-ui/text": "^0.0.1",
     "@novem-ui/theme": "^0.0.1-alpha.1"

--- a/packages/message/index.ts
+++ b/packages/message/index.ts
@@ -1,1 +1,2 @@
+export { MessageProps } from './src/types'
 export { default as Message } from './src'

--- a/packages/message/package.json
+++ b/packages/message/package.json
@@ -42,6 +42,7 @@
     "@types/novem-theme": "^0.0.1-alpha.1"
   },
   "dependencies": {
+    "@novem-ui/badge": "^0.0.1-alpha.1",
     "@novem-ui/base": "^0.0.1"
   }
 }

--- a/packages/message/src/index.spec.tsx
+++ b/packages/message/src/index.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import Button from '@novem-ui/button'
-import withTheme from '@novem-ui/theme/src/utils/with-theme'
+import { withTheme } from '@novem-ui/theme'
 import { cleanup, render } from '@testing-library/react'
 
 import Message from '.'

--- a/packages/message/src/index.tsx
+++ b/packages/message/src/index.tsx
@@ -3,9 +3,9 @@ import { Close as CloseIcon } from '@icon-park/react'
 import { FeedbackBadge } from '@novem-ui/badge'
 
 import { Content, Actions, IconWrapper, Text, Title, ContentWrapper, CloseWrapper, MessageWrapper } from './styles'
-import { MessageTypes } from './types'
+import { MessageProps } from './types'
 
-const Message: FunctionComponent<MessageTypes> = ({ title, message, onClose, action, baseColor, variant }) => (
+const Message: FunctionComponent<MessageProps> = ({ title, message, onClose, action, baseColor, variant }) => (
   <MessageWrapper baseColor={baseColor}>
     <Content>
       <IconWrapper>

--- a/packages/message/src/types.ts
+++ b/packages/message/src/types.ts
@@ -1,7 +1,7 @@
 import { ReactElement } from 'react'
 import theme from '@novem-ui/theme'
 
-export interface MessageTypes {
+export interface MessageProps {
   title?: string
   message: string
   onClose?: () => void

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -40,5 +40,8 @@
   "devDependencies": {
     "@novem-ui/theme": "^0.0.1-alpha.1",
     "@types/novem-theme": "^0.0.1-alpha.1"
+  },
+  "dependencies": {
+    "@novem-ui/base": "^0.0.1"
   }
 }


### PR DESCRIPTION
Here we check if we have an imported module without being listed as a dependency in the package.json